### PR TITLE
Deal with Large Inputs in Text Fields from Users

### DIFF
--- a/lib/schema/studentGrades.js
+++ b/lib/schema/studentGrades.js
@@ -5,7 +5,7 @@ const gradeMessage = 'Single letter grades accepted. Include "-" or "+" if neces
 const gradePattern = /^[aA][-]?$|^[b-dB-D][-|+]?$|^[fF]$/
 
 // Message for invalid letter grade input
-const nameMessage = 'Name must contain only letters or dashes'
+const nameMessage = '50 characters max containing only letters and dashes.'
 
 // Regexp for letter grade input validation
 const namePattern = /^[a-zA-Z](?:[a-zA-Z-]*[a-zA-Z]+)?$/
@@ -14,11 +14,13 @@ const schema = {
   properties: {
     firstName: {
       pattern: namePattern,
+      maxLength: 50,
       message: nameMessage,
       required: true
     },
     lastName: {
       pattern: namePattern,
+      maxLength: 50,
       message: nameMessage,
       required: true
     },

--- a/lib/schema/studentGrades.js
+++ b/lib/schema/studentGrades.js
@@ -5,7 +5,7 @@ const gradeMessage = 'Single letter grades accepted. Include "-" or "+" if neces
 const gradePattern = /^[aA][-]?$|^[b-dB-D][-|+]?$|^[fF]$/
 
 // Message for invalid letter grade input
-const nameMessage = '50 characters max containing only letters and dashes.'
+const nameMessage = '45 characters max containing only letters and dashes.'
 
 // Regexp for letter grade input validation
 const namePattern = /^[a-zA-Z](?:[a-zA-Z-]*[a-zA-Z]+)?$/
@@ -14,13 +14,13 @@ const schema = {
   properties: {
     firstName: {
       pattern: namePattern,
-      maxLength: 50,
+      maxLength: 45,
       message: nameMessage,
       required: true
     },
     lastName: {
       pattern: namePattern,
-      maxLength: 50,
+      maxLength: 45,
       message: nameMessage,
       required: true
     },

--- a/public/stylesheets/footer.css
+++ b/public/stylesheets/footer.css
@@ -9,5 +9,6 @@ div.footer {
 
 div.footer p {
   font-size: 12px;
+  margin-bottom: 10px;
   text-align: center;
 }

--- a/public/stylesheets/global.css
+++ b/public/stylesheets/global.css
@@ -20,7 +20,6 @@ html {
 
 .main-container {
   font-size: 20px;
-  margin-bottom: 20px;
   margin-left: auto;
   margin-right: auto;
   text-align: center;

--- a/public/stylesheets/input.css
+++ b/public/stylesheets/input.css
@@ -34,13 +34,14 @@ div.input-success {
   background-color: #d3f8d3;
   border: 2px solid green;
   border-radius: 15px;
+  display: inline-block;
   font-size: 16px;
   margin-bottom: 20px;
   margin-left: auto;
   margin-right: auto;
   min-height: 60px;
-  padding-top: 5px;
-  width: 600px;
+  padding: 5px 10px;
+  min-width: 600px;
 }
 
 div.input-success p {

--- a/public/stylesheets/qualified.css
+++ b/public/stylesheets/qualified.css
@@ -6,16 +6,25 @@ div.main-container p {
 table.students {
   border: 5px solid #d3d3d3;
   border-collapse: collapse;
+  font-family: 'Courier New', Courier, monospace;
   margin-bottom: 40px;
   margin-left: auto;
   margin-right: auto;
   table-layout: fixed;
-  min-width: 60%;
 }
 
 td.students {
   border: 1.5px solid #d3d3d3;
   padding: 12px 5px;
+}
+
+th.name-header {
+  width: 45%;
+}
+
+th.partial-gpa-header {
+  min-width: 160px;
+  width: 160px;
 }
 
 th.students {
@@ -25,5 +34,6 @@ th.students {
 }
 
 .partial-gpa {
-  width: 20%;
+  min-width: 160px;
+  width: 160px;
 }

--- a/public/stylesheets/qualified.css
+++ b/public/stylesheets/qualified.css
@@ -10,20 +10,12 @@ table.students {
   margin-left: auto;
   margin-right: auto;
   table-layout: fixed;
-  min-width: 80%;
+  min-width: 60%;
 }
 
 td.students {
   border: 1.5px solid #d3d3d3;
-  padding: 12px 0px;
-}
-
-td.students.small {
-  font-size: 14px;
-}
-
-td.students.xsmall {
-  font-size: 12px;
+  padding: 12px 5px;
 }
 
 th.students {

--- a/views/qualified.ejs
+++ b/views/qualified.ejs
@@ -19,8 +19,8 @@
               <% if (locals.students) { %>
                 <% students.forEach(({ firstName, lastName, partialGPA }) => { %>
                   <tr>
-                    <td class="students<% if (lastName.length >= 30 && lastName.length < 60) { %> small<% } %><% if (lastName.length >= 60) { %> xsmall<% } %>"><%= lastName %></td>
-                    <td class="students<% if (firstName.length >= 30 && firstName.length < 60) { %> small<% } %><% if (firstName.length >= 60) { %> xsmall<% } %>"><%= firstName %></td>
+                    <td class="students"><%= lastName %></td>
+                    <td class="students"><%= firstName %></td>
                     <td class="students partial-gpa"><%= partialGPA %></td>
                   </tr>
                 <% }) %>

--- a/views/qualified.ejs
+++ b/views/qualified.ejs
@@ -12,9 +12,9 @@
           <% if (students.length) { %>
             <table class="students">
               <tr>
-                <th class="students">Last Name</th>
-                <th class="students">First Name</th>
-                <th class="students partial-gpa">Partial GPA</th>
+                <th class="students name-header">Last Name</th>
+                <th class="students name-header">First Name</th>
+                <th class="students partial-gpa-header">Partial GPA</th>
               </tr>
               <% if (locals.students) { %>
                 <% students.forEach(({ firstName, lastName, partialGPA }) => { %>


### PR DESCRIPTION
Addressing some issues with large text inputs from users on the `/inputs` endpoint.  A couple of the things that were implemented to deal with this include:

- Setting a max on the first and last name fields to 45 characters.
- Setting the table layout to `fixed` with a `width` set to `100%`.
- Using a monospaced font, `Courier New`, so we have more control over how much space the names take up in the `Qualified Students` table.  We won't have to deal with text overflowing in weird ways in the table depending on the characters typed, like `i` and `m`.  With regular fonts they have much different spacing characters that make it difficult to deal with all the different possible combinations of inputs.

Fixes https://github.com/PurrBiscuit/csc-404-project-2/issues/19